### PR TITLE
Security fix, extra test

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Looking to use the Paytr protocol for your project? Check out our documentation 
 
 ## Truffle test
 
-All the tests are located in the `test/paytr.test.js`file.
+All the tests are located in the test folder.
 Install the necessary dependencies like Ganache and Truffle.
 
 We recommend to fork Mainnet and unlock an account which holds a lot of USDC, by using this command:

--- a/contracts/Paytr.sol
+++ b/contracts/Paytr.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity >=0.8.0 <0.9.0;
+pragma solidity ^0.8.19;
 
 import "@openzeppelin/contracts/access/Ownable.sol";
 import "@openzeppelin/contracts/security/ReentrancyGuard.sol";
@@ -200,11 +200,11 @@ contract Paytr is Ownable, Pausable, ReentrancyGuard {
             IComet(cometAddress).withdraw(baseAsset, cTokensToRedeem);
 
             //get new USDC balance
-            uint256 _totalInterestGathered = IERC20(baseAsset).balanceOf(address(this)) - _amount;
+            uint256 _totalInterestGathered = IERC20(baseAsset).balanceOf(address(this)) - _amount - _feeAmount;
             uint256 _interestAmount = _totalInterestGathered * feeModifier / 10000;
 
             if(allowedRequestNetworkFeeAddresses[_feeAddress] == true) {
-                IERC20(baseAsset).safeApprove(ERC20FeeProxyAddress, _amount + _feeAmount);
+                IERC20(baseAsset).forceApprove(ERC20FeeProxyAddress, _amount + _feeAmount);
 
                 IERC20FeeProxy(ERC20FeeProxyAddress).transferFromWithReferenceAndFee(
                         baseAsset,

--- a/test/paytr_test_feePayment.js
+++ b/test/paytr_test_feePayment.js
@@ -1,0 +1,94 @@
+var assert = require('assert');
+const truffleAssert = require('truffle-assertions');
+const { time } = require("@openzeppelin/test-helpers");
+const Paytr = artifacts.require("Paytr");
+const {CometContract, wrapperContract, USDCContract, cTokenContract, whaleAccount, provider} = require('./helpers/parameters');
+
+let amountToPay = 150000000;
+let cometSupplyRateParam = web3.utils.toBN(10**18);
+let feeAmount = 1500000;
+
+contract("Paytr", (accounts) => {  
+
+  let instance;
+  beforeEach('should setup the contract instances', async () => {
+    instance = await Paytr.deployed();
+  });  
+  
+  it("should be able to make an ERC20 payment with an extra fee", async () => {
+    const payee = accounts[6];
+    let feeReceiver = accounts[5];
+
+    //check supply rate
+    let supplyRate = await CometContract.methods.getSupplyRate(cometSupplyRateParam).call();
+    assert(supplyRate > 0);
+
+    await USDCContract.methods.approve(instance.address, 1000000000000).send({from: whaleAccount});
+    let wTokenBalanceBeforeTx = await wrapperContract.methods.balanceOf(instance.address).call();
+    let contractCUSDCTokenBalanceBeforeTx = await cTokenContract.methods.balanceOf(instance.address).call();
+    let whaleAccountBalanceBeforeTx = await USDCContract.methods.balanceOf(whaleAccount).call();
+    let feeReceiverAccountBalanceBeforeTx = await USDCContract.methods.balanceOf(feeReceiver).call();
+    
+    let currentTime = await time.latest();
+    let numberOfDaysToAdd = web3.utils.toBN(30);
+    let dueDate = web3.utils.toBN(currentTime).add((numberOfDaysToAdd).mul(web3.utils.toBN(86400))).toString();
+
+    let payment = await instance.payInvoiceERC20(
+      payee,
+      feeReceiver, //dummy feeAddress
+      dueDate,
+      amountToPay,
+      feeAmount, //no fee requires 0 as parameter input        
+      "0x494e56332d32343034",
+      {from: whaleAccount}
+    );
+    truffleAssert.eventEmitted(payment, "PaymentERC20Event");
+
+    let contractCUSDCTokenBalanceAfterTx = await cTokenContract.methods.balanceOf(instance.address).call();
+    let wTokenBalanceAfterTx = await wrapperContract.methods.balanceOf(instance.address).call();
+    let expectedWhaleAccountBalanceAfterTx = web3.utils.toBN(whaleAccountBalanceBeforeTx).sub(web3.utils.toBN(amountToPay)).sub(web3.utils.toBN(feeAmount)).toString();
+    let whaleAccountBalanceAfterTx = await USDCContract.methods.balanceOf(whaleAccount).call();
+
+    assert.equal(whaleAccountBalanceAfterTx,expectedWhaleAccountBalanceAfterTx,"Whale account balance doens't match expected balance");
+    assert.equal(contractCUSDCTokenBalanceBeforeTx, contractCUSDCTokenBalanceAfterTx,"Contract cToken balance doesn't match");
+    assert(wTokenBalanceAfterTx > wTokenBalanceBeforeTx, "wToken balance hasn't changed");
+
+    //increase time and block number to force interest gathering. Without both, Truffle test throws an arithmetic overflow error
+    let currentBlock = await web3.eth.getBlockNumber();
+    await provider.request({method: 'evm_increaseTime', params: [10000000]});
+    await time.advanceBlockTo(currentBlock + 999); //999 + 1 block
+
+    //test redeem
+    let contractUSDCTokenBalanceBeforeRedeeming = await USDCContract.methods.balanceOf(instance.address).call();
+    let contractCUSDCTokenBalanceBeforeRedeeming = await cTokenContract.methods.balanceOf(instance.address).call();
+    let payeeUSDCBalanceBeforePayout = await USDCContract.methods.balanceOf(accounts[6]).call();
+
+    //create array with payment references to redeem
+    let redeemArray = [];
+    redeemArray.push("0x494e56332d32343034");
+
+    //test redeem from Compound
+    await instance.payOutERC20Invoice(redeemArray);
+
+    let contractCUSDCTokenBalanceAfterRedeeming = await cTokenContract.methods.balanceOf(instance.address).call();
+    let contractUSDCTokenBalanceAfterRedeeming = await USDCContract.methods.balanceOf(instance.address).call();
+    let wTokenBalanceAfterRedeeming = await wrapperContract.methods.balanceOf(instance.address).call();
+    let feeReceiverAccountBalanceAfterTx = await USDCContract.methods.balanceOf(feeReceiver).call();
+    let expectedFeeReceiverBalanceAfterTx = web3.utils.toBN(feeReceiverAccountBalanceBeforeTx).add(web3.utils.toBN(feeAmount)).toString();
+    console.log("Fee receiver USDC balance after tx: ",feeReceiverAccountBalanceAfterTx);
+
+    let payeeUSDCBalanceAfterPayout = await USDCContract.methods.balanceOf(accounts[6]).call();
+    let expectedPayeeUSDCBalanceAfterPayout = web3.utils.toBN(payeeUSDCBalanceBeforePayout).add(web3.utils.toBN(amountToPay));
+    let whaleAccountBalanceAfterInterestPayout = await USDCContract.methods.balanceOf(whaleAccount).call();
+    assert(whaleAccountBalanceAfterInterestPayout> whaleAccountBalanceAfterTx,"Wrong whale balance after payout");
+    assert.equal(expectedPayeeUSDCBalanceAfterPayout, payeeUSDCBalanceAfterPayout,"Payee USDC balance doesn't match");
+    assert.equal(contractCUSDCTokenBalanceAfterRedeeming,0,"Contract's cToken balance != 0");
+    assert(contractUSDCTokenBalanceBeforeRedeeming < contractUSDCTokenBalanceAfterRedeeming,"Contract USDC balance didn't increase");
+    assert.equal(contractCUSDCTokenBalanceBeforeRedeeming, contractCUSDCTokenBalanceAfterRedeeming,"Contract cToken balance doesn't match");
+    assert(wTokenBalanceAfterRedeeming <= 1, "Wrong wrapped token balance;");
+    assert(feeReceiverAccountBalanceAfterTx > feeReceiverAccountBalanceBeforeTx, "Fee receiver's balance did not increase");
+    assert.equal(feeReceiverAccountBalanceAfterTx, expectedFeeReceiverBalanceAfterTx, "Fee amount mismatch in receiver's account");
+
+  });
+
+});


### PR DESCRIPTION
Fix: added the _feeAmount susbtraction in the interest calculation.
Without this, the calculated interest amount would be too high, resulting in the payer receiving too much interest and the feeAddress not getting the complete feeAmount.

Added test for a fee payment scenario.